### PR TITLE
Refine clipboard

### DIFF
--- a/packages/core/src/modules/clipboard.ts
+++ b/packages/core/src/modules/clipboard.ts
@@ -17,6 +17,7 @@ export default class clipboard {
       ele.focus({ preventScroll: true });
       document.execCommand("selectAll");
       document.execCommand("copy");
+      setTimeout(() => ele?.blur(), 10);
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
Refines 9c5cbdb

A `focus` should be followed by a `blur`.

Ref: https://github.com/dream-num/Luckysheet/blob/7b6c7f8dfb40404a0bd8d0b613f8056819bf1bf0/src/controllers/selection.js#L557